### PR TITLE
Fixing POST /short-message request body example value and declaration

### DIFF
--- a/code/API_definitions/SMS.yaml
+++ b/code/API_definitions/SMS.yaml
@@ -62,12 +62,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MessageRequest'
-            example:
+            examples:
               MessageRequest:
-                to: '+910123456789'
-                from: '+919876543210'
-                category: PROMOTION
-                message: xxxxxxxxxx
+                value:
+                  to: ['+910123456789']
+                  from: '+919876543210'
+                  category: PROMOTION
+                  message: xxxxxxxxxx
         required: true
       responses:
         '200':


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:

Fixes POST /short-message request body example value and declaration, which leads to tooling (Postman, ReDoc, Swagger, ...) generating wrong values and user copy/pasting wrong values.

- Fix example declaration (`examples` with correct syntax)
- Fix example value (`to` is an array)

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #15 

